### PR TITLE
Normalised sections in files

### DIFF
--- a/scripts/isxdl/isxdl.iss
+++ b/scripts/isxdl/isxdl.iss
@@ -10,3 +10,5 @@ external 'isxdl_DownloadFiles@files:isxdl.dll stdcall';
 
 function isxdl_SetOption(Option, Value: PAnsiChar): Integer;
 external 'isxdl_SetOption@files:isxdl.dll stdcall';
+
+[Setup]

--- a/scripts/products.iss
+++ b/scripts/products.iss
@@ -30,7 +30,6 @@ de.depinstall_error=Ein Fehler ist während der Installation der Abghängigkeiten 
 en.isxdl_langfile=
 de.isxdl_langfile=german2.ini
 
-
 [Files]
 Source: "scripts\isxdl\german2.ini"; Flags: dontcopy
 
@@ -271,3 +270,5 @@ procedure SetForceX86(value: boolean);
 begin
 	isForcedX86 := value;
 end;
+
+[Setup]

--- a/scripts/products/directxruntime.iss
+++ b/scripts/products/directxruntime.iss
@@ -1,5 +1,5 @@
-// requires Windows 7, Windows Server 2003 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Vista, Windows XP Service Pack 2, Windows XP Service Pack 3
-// http://www.microsoft.com/en-US/download/details.aspx?id=35
+; requires Windows 7, Windows Server 2003 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Vista, Windows XP Service Pack 2, Windows XP Service Pack 3
+; http://www.microsoft.com/en-US/download/details.aspx?id=35
 
 [CustomMessages]
 en.directxruntime_title=DirectX End-User Runtime
@@ -27,3 +27,5 @@ begin
 		directxruntime_url,
 		true, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx11.iss
+++ b/scripts/products/dotnetfx11.iss
@@ -1,13 +1,12 @@
-// requires Windows 2000; Windows Server 2003 Service Pack 1 for Itanium-based Systems; Windows Server 2003 x64 editions; Windows Server 2008 Datacenter; Windows Server 2008 Enterprise; Windows Server 2008 for Itanium-based Systems; Windows Server 2008 Standard; Windows Vista Business; Windows Vista Enterprise; Windows Vista Home Basic; Windows Vista Home Premium; Windows Vista Starter; Windows Vista Ultimate; Windows XP; Windows XP Professional x64 Edition; Windows NT 4.0 Service Pack 6a
-// requires internet explorer 5.0.1 or higher
-// http://www.microsoft.com/downloads/details.aspx?FamilyID=262d25e3-f589-4842-8157-034d1e7cf3a3
+; requires Windows 2000; Windows Server 2003 Service Pack 1 for Itanium-based Systems; Windows Server 2003 x64 editions; Windows Server 2008 Datacenter; Windows Server 2008 Enterprise; Windows Server 2008 for Itanium-based Systems; Windows Server 2008 Standard; Windows Vista Business; Windows Vista Enterprise; Windows Vista Home Basic; Windows Vista Home Premium; Windows Vista Starter; Windows Vista Ultimate; Windows XP; Windows XP Professional x64 Edition; Windows NT 4.0 Service Pack 6a
+; requires internet explorer 5.0.1 or higher
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=262d25e3-f589-4842-8157-034d1e7cf3a3
 
 [CustomMessages]
 dotnetfx11_title=.NET Framework 1.1
 
 en.dotnetfx11_size=23.1 MB
 de.dotnetfx11_size=23,1 MB
-
 
 [Code]
 const
@@ -23,3 +22,5 @@ begin
 			dotnetfx11_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx11lp.iss
+++ b/scripts/products/dotnetfx11lp.iss
@@ -8,7 +8,6 @@ de.dotnetfx11lp_lcid=1031
 
 de.dotnetfx11lp_url=http://download.microsoft.com/download/6/8/2/6821e687-526a-4ef8-9a67-9a402ec5ac9e/langpack.exe
 
-
 [Code]
 procedure dotnetfx11lp();
 begin
@@ -22,3 +21,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx11sp1.iss
+++ b/scripts/products/dotnetfx11sp1.iss
@@ -1,13 +1,12 @@
-// requires TabletPC, Windows 2000, Windows 2000 Advanced Server, Windows 2000 Professional Edition , Windows 2000 Server, Windows 2000 Service Pack 2, Windows 2000 Service Pack 3, Windows 2000 Service Pack 4, Windows Server 2003 Service Pack 1 for Itanium-based Systems, Windows Server 2003 x64 editions, Windows Server 2003, Datacenter Edition for 64-Bit Itanium-Based Systems, Windows Server 2003, Datacenter x64 Edition, Windows Server 2003, Enterprise Edition for Itanium-based Systems, Windows Server 2003, Enterprise x64 Edition, Windows Server 2003, Standard x64 Edition, Windows Server 2008 Datacenter, Windows Server 2008 Enterprise, Windows Server 2008 for Itanium-based Systems, Windows Server 2008 Standard, Windows Vista Business, Windows Vista Business 64-bit edition, Windows Vista Enterprise, Windows Vista Enterprise 64-bit edition, Windows Vista Home Basic, Windows Vista Home Basic 64-bit edition, Windows Vista Home Premium, Windows Vista Home Premium 64-bit edition, Windows Vista Starter, Windows Vista Ultimate, Windows Vista Ultimate 64-bit edition, Windows XP, Windows XP Home Edition , Windows XP Media Center Edition, Windows XP Professional Edition , Windows XP Professional x64 Edition , Windows XP Service Pack 1, Windows XP Service Pack 2
-// requires internet explorer 5.0.1 or higher
-// http://www.microsoft.com/downloads/details.aspx?familyid=A8F5654F-088E-40B2-BBDB-A83353618B38
+; requires TabletPC, Windows 2000, Windows 2000 Advanced Server, Windows 2000 Professional Edition , Windows 2000 Server, Windows 2000 Service Pack 2, Windows 2000 Service Pack 3, Windows 2000 Service Pack 4, Windows Server 2003 Service Pack 1 for Itanium-based Systems, Windows Server 2003 x64 editions, Windows Server 2003, Datacenter Edition for 64-Bit Itanium-Based Systems, Windows Server 2003, Datacenter x64 Edition, Windows Server 2003, Enterprise Edition for Itanium-based Systems, Windows Server 2003, Enterprise x64 Edition, Windows Server 2003, Standard x64 Edition, Windows Server 2008 Datacenter, Windows Server 2008 Enterprise, Windows Server 2008 for Itanium-based Systems, Windows Server 2008 Standard, Windows Vista Business, Windows Vista Business 64-bit edition, Windows Vista Enterprise, Windows Vista Enterprise 64-bit edition, Windows Vista Home Basic, Windows Vista Home Basic 64-bit edition, Windows Vista Home Premium, Windows Vista Home Premium 64-bit edition, Windows Vista Starter, Windows Vista Ultimate, Windows Vista Ultimate 64-bit edition, Windows XP, Windows XP Home Edition , Windows XP Media Center Edition, Windows XP Professional Edition , Windows XP Professional x64 Edition , Windows XP Service Pack 1, Windows XP Service Pack 2
+; requires internet explorer 5.0.1 or higher
+; http://www.microsoft.com/downloads/details.aspx?familyid=A8F5654F-088E-40B2-BBDB-A83353618B38
 
 [CustomMessages]
 dotnetfx11sp1_title=.NET Framework 1.1 Service Pack 1
 
 en.dotnetfx11sp1_size=10.5 MB
 de.dotnetfx11sp1_size=10,5 MB
-
 
 [Code]
 const
@@ -23,3 +22,5 @@ begin
 			dotnetfx11sp1_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20.iss
+++ b/scripts/products/dotnetfx20.iss
@@ -1,14 +1,13 @@
-// requires Windows 2000 Service Pack 3, Windows 98, Windows 98 Second Edition, Windows ME, Windows Server 2003, Windows XP Service Pack 2
-// requires internet explorer 5.0.1 or higher
-// requires windows installer 2.0 on windows 98, ME
-// requires Windows Installer 3.1 on windows 2000 or higher
-// http://www.microsoft.com/downloads/details.aspx?FamilyID=0856eacb-4362-4b0d-8edd-aab15c5e04f5
+; requires Windows 2000 Service Pack 3, Windows 98, Windows 98 Second Edition, Windows ME, Windows Server 2003, Windows XP Service Pack 2
+; requires internet explorer 5.0.1 or higher
+; requires windows installer 2.0 on windows 98, ME
+; requires Windows Installer 3.1 on windows 2000 or higher
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=0856eacb-4362-4b0d-8edd-aab15c5e04f5
 
 [CustomMessages]
 dotnetfx20_title=.NET Framework 2.0
 
 dotnetfx20_size=23 MB
-
 
 [Code]
 const
@@ -26,3 +25,5 @@ begin
 			GetString(dotnetfx20_url, dotnetfx20_url_x64, dotnetfx20_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20lp.iss
+++ b/scripts/products/dotnetfx20lp.iss
@@ -1,4 +1,4 @@
-//http://www.microsoft.com/downloads/details.aspx?familyid=92E0E1CE-8693-4480-84FA-7D85EEF59016
+; http://www.microsoft.com/downloads/details.aspx?familyid=92E0E1CE-8693-4480-84FA-7D85EEF59016
 
 [CustomMessages]
 de.dotnetfx20lp_title=.NET Framework 2.0 Sprachpaket: Deutsch
@@ -11,7 +11,6 @@ de.dotnetfx20lp_lcid=1031
 de.dotnetfx20lp_url=http://download.microsoft.com/download/2/9/7/29768238-56c3-4ea6-abba-4c5246f2bc81/langpack.exe
 de.dotnetfx20lp_url_x64=http://download.microsoft.com/download/2/e/f/2ef250ba-a868-4074-a4c9-249004866f87/langpack.exe
 de.dotnetfx20lp_url_ia64=http://download.microsoft.com/download/8/9/8/898c5670-5e74-41c4-82fc-68dd837af627/langpack.exe
-
 
 [Code]
 procedure dotnetfx20lp();
@@ -26,3 +25,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20sp1.iss
+++ b/scripts/products/dotnetfx20sp1.iss
@@ -1,13 +1,12 @@
-// requires Windows 2000 Service Pack 4, Windows Server 2003, Windows XP Service Pack 2
-// requires KB 835732 on Windows 2000 Service Pack 4
-// http://www.microsoft.com/downloads/details.aspx?FamilyID=79bc3b77-e02c-4ad3-aacf-a7633f706ba5
+; requires Windows 2000 Service Pack 4, Windows Server 2003, Windows XP Service Pack 2
+; requires KB 835732 on Windows 2000 Service Pack 4
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=79bc3b77-e02c-4ad3-aacf-a7633f706ba5
 
 [CustomMessages]
 dotnetfx20sp1_title=.NET Framework 2.0 Service Pack 1
 
 en.dotnetfx20sp1_size=23.6 MB
 de.dotnetfx20sp1_size=23,6 MB
-
 
 [Code]
 const
@@ -25,3 +24,5 @@ begin
 			GetString(dotnetfx20sp1_url, dotnetfx20sp1_url_x64, dotnetfx20sp1_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20sp1lp.iss
+++ b/scripts/products/dotnetfx20sp1lp.iss
@@ -1,4 +1,4 @@
-//http://www.microsoft.com/downloads/details.aspx?FamilyID=1cc39ffe-a2aa-4548-91b3-855a2de99304
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=1cc39ffe-a2aa-4548-91b3-855a2de99304
 
 [CustomMessages]
 de.dotnetfx20sp1lp_title=.NET Framework 2.0 SP1 Sprachpaket: Deutsch
@@ -11,7 +11,6 @@ de.dotnetfx20sp1lp_lcid=1031
 de.dotnetfx20sp1lp_url=http://download.microsoft.com/download/8/a/a/8aab7e6a-5e58-4e83-be99-f5fb49fe811e/NetFx20SP1_x86de.exe
 de.dotnetfx20sp1lp_url_x64=http://download.microsoft.com/download/1/4/2/1425872f-c564-4ab2-8c9e-344afdaecd44/NetFx20SP1_x64de.exe
 de.dotnetfx20sp1lp_url_ia64=http://download.microsoft.com/download/a/0/b/a0bef431-19d8-433c-9f42-6e2824a8cb90/NetFx20SP1_ia64de.exe
-
 
 [Code]
 procedure dotnetfx20sp1lp();
@@ -26,3 +25,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20sp2.iss
+++ b/scripts/products/dotnetfx20sp2.iss
@@ -1,11 +1,10 @@
-//http://www.microsoft.com/downloads/details.aspx?familyid=5B2C0358-915B-4EB5-9B1D-10E506DA9D0F
+; http://www.microsoft.com/downloads/details.aspx?familyid=5B2C0358-915B-4EB5-9B1D-10E506DA9D0F
 
 [CustomMessages]
 dotnetfx20sp2_title=.NET Framework 2.0 Service Pack 2
 
 en.dotnetfx20sp2_size=24 MB - 52 MB
 de.dotnetfx20sp2_size=24 MB - 52 MB
-
 
 [Code]
 const
@@ -23,3 +22,5 @@ begin
 			GetString(dotnetfx20sp2_url, dotnetfx20sp2_url_x64, dotnetfx20sp2_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx20sp2lp.iss
+++ b/scripts/products/dotnetfx20sp2lp.iss
@@ -1,4 +1,4 @@
-//http://www.microsoft.com/downloads/details.aspx?FamilyID=c69789e0-a4fa-4b2e-a6b5-3b3695825992
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=c69789e0-a4fa-4b2e-a6b5-3b3695825992
 
 [CustomMessages]
 de.dotnetfx20sp2lp_title=.NET Framework 2.0 SP2 Sprachpaket: Deutsch
@@ -11,7 +11,6 @@ de.dotnetfx20sp2lp_lcid=1031
 de.dotnetfx20sp2lp_url=http://download.microsoft.com/download/0/b/1/0b175c8e-34bd-46c0-bfcd-af8d33770c58/netfx20sp2_x86de.exe
 de.dotnetfx20sp2lp_url_x64=http://download.microsoft.com/download/4/e/c/4ec67a11-879d-4550-9c25-fd9ab4261b46/netfx20sp2_x64de.exe
 de.dotnetfx20sp2lp_url_ia64=http://download.microsoft.com/download/a/3/3/a3349a2d-36e4-4797-8297-4394e6fbd677/NetFx20SP2_ia64de.exe
-
 
 [Code]
 procedure dotnetfx20sp2lp();
@@ -26,3 +25,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx35.iss
+++ b/scripts/products/dotnetfx35.iss
@@ -1,13 +1,12 @@
-// requires Windows Server 2003 Service Pack 1, Windows Server 2008, Windows Vista, Windows XP Service Pack 2
-// requires Windows Installer 3.1
-// WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-// http://www.microsoft.com/downloads/details.aspx?FamilyId=333325FD-AE52-4E35-B531-508D977D32A6
+; requires Windows Server 2003 Service Pack 1, Windows Server 2008, Windows Vista, Windows XP Service Pack 2
+; requires Windows Installer 3.1
+; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
+; http://www.microsoft.com/downloads/details.aspx?FamilyId=333325FD-AE52-4E35-B531-508D977D32A6
 
 [CustomMessages]
 dotnetfx35_title=.NET Framework 3.5
 
 dotnetfx35_size=3 MB - 197 MB
-
 
 [Code]
 const
@@ -23,3 +22,5 @@ begin
 			dotnetfx35_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx35lp.iss
+++ b/scripts/products/dotnetfx35lp.iss
@@ -8,7 +8,6 @@ de.dotnetfx35lp_lcid=1031
 
 de.dotnetfx35lp_url=http://download.microsoft.com/download/d/1/e/d1e617c3-c7f4-467e-a7de-af832450efd3/dotnetfx35langpack_x86de.exe
 
-
 [Code]
 procedure dotnetfx35lp();
 begin
@@ -22,3 +21,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx35sp1.iss
+++ b/scripts/products/dotnetfx35sp1.iss
@@ -1,14 +1,13 @@
-// requires Windows Server 2003 Service Pack 1, Windows Server 2008, Windows Vista, Windows XP Service Pack 2
-// requires Windows Installer 3.1
-// WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-// http://www.microsoft.com/downloads/details.aspx?FamilyID=ab99342f-5d1a-413d-8319-81da479ab0d7
+; requires Windows Server 2003 Service Pack 1, Windows Server 2008, Windows Vista, Windows XP Service Pack 2
+; requires Windows Installer 3.1
+; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
+; http://www.microsoft.com/downloads/details.aspx?FamilyID=ab99342f-5d1a-413d-8319-81da479ab0d7
 
 [CustomMessages]
 dotnetfx35sp1_title=.NET Framework 3.5 Service Pack 1
 
 en.dotnetfx35sp1_size=3 MB - 232 MB
 de.dotnetfx35sp1_size=3 MB - 232 MB
-
 
 [Code]
 const
@@ -24,3 +23,5 @@ begin
 			dotnetfx35sp1_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx35sp1lp.iss
+++ b/scripts/products/dotnetfx35sp1lp.iss
@@ -8,7 +8,6 @@ de.dotnetfx35sp1lp_lcid=1031
 
 de.dotnetfx35sp1lp_url=http://download.microsoft.com/download/d/7/2/d728b7b9-454b-4b57-8270-45dac441b0ec/dotnetfx35langpack_x86de.exe
 
-
 [Code]
 procedure dotnetfx35sp1lp();
 begin
@@ -22,3 +21,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx40client.iss
+++ b/scripts/products/dotnetfx40client.iss
@@ -1,8 +1,8 @@
-// requires Windows 7, Windows 7 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Server 2008 R2, Windows Server 2008 R2 SP1, Windows Vista Service Pack 1, Windows XP Service Pack 3
-// requires Windows Installer 3.1
-// requires Internet Explorer 5.01
-// WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-// http://www.microsoft.com/downloads/en/details.aspx?FamilyID=5765d7a8-7722-4888-a970-ac39b33fd8ab
+; requires Windows 7, Windows 7 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Server 2008 R2, Windows Server 2008 R2 SP1, Windows Vista Service Pack 1, Windows XP Service Pack 3
+; requires Windows Installer 3.1
+; requires Internet Explorer 5.01
+; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
+; http://www.microsoft.com/downloads/en/details.aspx?FamilyID=5765d7a8-7722-4888-a970-ac39b33fd8ab
 
 [CustomMessages]
 dotnetfx40client_title=.NET Framework 4.0 Client
@@ -12,7 +12,6 @@ dotnetfx40client_size=3 MB - 197 MB
 ;http://www.microsoft.com/globaldev/reference/lcid-all.mspx
 en.dotnetfx40client_lcid=
 de.dotnetfx40client_lcid=/lcid 1031
-
 
 [Code]
 const
@@ -28,3 +27,5 @@ begin
 			dotnetfx40client_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx40full.iss
+++ b/scripts/products/dotnetfx40full.iss
@@ -1,8 +1,8 @@
-// requires Windows 7, Windows 7 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Server 2008 R2, Windows Server 2008 R2 SP1, Windows Vista Service Pack 1, Windows XP Service Pack 3
-// requires Windows Installer 3.1
-// requires Internet Explorer 5.01
-// WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-// http://www.microsoft.com/downloads/en/details.aspx?FamilyID=9cfb2d51-5ff4-4491-b0e5-b386f32c0992
+; requires Windows 7, Windows 7 Service Pack 1, Windows Server 2003 Service Pack 2, Windows Server 2008, Windows Server 2008 R2, Windows Server 2008 R2 SP1, Windows Vista Service Pack 1, Windows XP Service Pack 3
+; requires Windows Installer 3.1
+; requires Internet Explorer 5.01
+; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
+; http://www.microsoft.com/downloads/en/details.aspx?FamilyID=9cfb2d51-5ff4-4491-b0e5-b386f32c0992
 
 [CustomMessages]
 dotnetfx40full_title=.NET Framework 4.0 Full
@@ -12,7 +12,6 @@ dotnetfx40full_size=3 MB - 197 MB
 ;http://www.microsoft.com/globaldev/reference/lcid-all.mspx
 en.dotnetfx40full_lcid=
 de.dotnetfx40full_lcid=/lcid 1031
-
 
 [Code]
 const
@@ -28,3 +27,5 @@ begin
 			dotnetfx40full_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfx46.iss
+++ b/scripts/products/dotnetfx46.iss
@@ -1,6 +1,6 @@
-// requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2
-// WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-// http://www.microsoft.com/en-us/download/details.aspx?id=48137
+; requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2
+; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
+; http://www.microsoft.com/en-us/download/details.aspx?id=48137
 
 [CustomMessages]
 dotnetfx46_title=.NET Framework 4.6
@@ -10,7 +10,6 @@ dotnetfx46_size=1 MB - 63 MB
 ;http://www.microsoft.com/globaldev/reference/lcid-all.mspx
 en.dotnetfx46_lcid=
 de.dotnetfx46_lcid=/lcid 1031
-
 
 [Code]
 const
@@ -26,3 +25,5 @@ begin
 			dotnetfx46_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/dotnetfxversion.iss
+++ b/scripts/products/dotnetfxversion.iss
@@ -86,3 +86,5 @@ begin
 	end;
 	Result := regVersion;
 end;
+
+[Setup]

--- a/scripts/products/fileversion.iss
+++ b/scripts/products/fileversion.iss
@@ -21,3 +21,5 @@ begin
 	else
 		Result := '0';
 end;
+
+[Setup]

--- a/scripts/products/ie6.iss
+++ b/scripts/products/ie6.iss
@@ -1,13 +1,12 @@
-// requires Windows 2000; Windows 98; Windows ME; Windows NT; Windows XP Service Pack 1
-// WARNING: express setup (downloads and installs the components depending on your OS)
-// http://www.microsoft.com/downloads/details.aspx?familyid=1E1550CB-5E5D-48F5-B02B-20B602228DE6
+; requires Windows 2000; Windows 98; Windows ME; Windows NT; Windows XP Service Pack 1
+; WARNING: express setup (downloads and installs the components depending on your OS)
+; http://www.microsoft.com/downloads/details.aspx?familyid=1E1550CB-5E5D-48F5-B02B-20B602228DE6
 
 [CustomMessages]
 ie6_title=Internet Explorer 6
 
 en.ie6_size=1 MB - 77.5 MB
 de.ie6_size=1 MB - 77,5 MB
-
 
 [Code]
 const
@@ -26,3 +25,5 @@ begin
 			ie6_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/iis.iss
+++ b/scripts/products/iis.iss
@@ -1,7 +1,6 @@
 [CustomMessages]
 iis_title=Internet Information Services (IIS)
 
-
 [Code]
 function iis(): boolean;
 begin
@@ -10,3 +9,5 @@ begin
 	else
 		Result := true;
 end;
+
+[Setup]

--- a/scripts/products/jet4sp8.iss
+++ b/scripts/products/jet4sp8.iss
@@ -1,11 +1,10 @@
-// http://support.microsoft.com/kb/239114
+; http://support.microsoft.com/kb/239114
 
 [CustomMessages]
 jet4sp8_title=Jet 4
 
 en.jet4sp8_size=3.7 MB
 de.jet4sp8_size=3,7 MB
-
 
 [Code]
 const
@@ -22,3 +21,5 @@ begin
 			jet4sp8_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/kb835732.iss
+++ b/scripts/products/kb835732.iss
@@ -1,6 +1,6 @@
-// required by .NET Framework 2.0 Service Pack 1 on Windows 2000 Service Pack 2-4
-// http://www.microsoft.com/technet/security/bulletin/ms04-011.mspx
-// http://www.microsoft.com/downloads/details.aspx?FamilyId=0692C27E-F63A-414C-B3EB-D2342FBB6C00
+; required by .NET Framework 2.0 Service Pack 1 on Windows 2000 Service Pack 2-4
+; http://www.microsoft.com/technet/security/bulletin/ms04-011.mspx
+; http://www.microsoft.com/downloads/details.aspx?FamilyId=0692C27E-F63A-414C-B3EB-D2342FBB6C00
 
 [CustomMessages]
 en.kb835732_title=Windows 2000 Security Update (KB835732)
@@ -8,7 +8,6 @@ de.kb835732_title=Windows 2000 Sicherheitsupdate (KB835732)
 
 en.kb835732_size=6.8 MB
 de.kb835732_size=6,8 MB
-
 
 [Code]
 const
@@ -26,3 +25,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/mdac28.iss
+++ b/scripts/products/mdac28.iss
@@ -4,7 +4,6 @@ mdac28_title=Microsoft Data Access Components 2.8
 en.mdac28_size=5.4 MB
 de.mdac28_size=5,4 MB
 
-
 [Code]
 const
 	mdac28_url = 'http://download.microsoft.com/download/c/d/f/cdfd58f1-3973-4c51-8851-49ae3777586f/MDAC_TYP.EXE';
@@ -23,3 +22,5 @@ begin
 			mdac28_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/msi20.iss
+++ b/scripts/products/msi20.iss
@@ -4,7 +4,6 @@ msi20_title=Windows Installer 2.0
 en.msi20_size=1.7 MB
 de.msi20_size=1,7 MB
 
-
 [Code]
 const
 	msi20_url = 'http://download.microsoft.com/download/WindowsInstaller/Install/2.0/W9XMe/EN-US/InstMsiA.exe';
@@ -20,3 +19,5 @@ begin
 			msi20_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/msi31.iss
+++ b/scripts/products/msi31.iss
@@ -4,7 +4,6 @@ msi31_title=Windows Installer 3.1
 en.msi31_size=2.5 MB
 de.msi31_size=2,5 MB
 
-
 [Code]
 const
 	msi31_url = 'http://download.microsoft.com/download/1/4/7/147ded26-931c-4daf-9095-ec7baf996f46/WindowsInstaller-KB893803-v2-x86.exe';
@@ -20,3 +19,5 @@ begin
 			msi31_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/msi45.iss
+++ b/scripts/products/msi45.iss
@@ -10,7 +10,6 @@ de.msi45win52_size=3,0 MB
 en.msi45win51_size=3.2 MB
 de.msi45win51_size=3,2 MB
 
-
 [Code]
 const
 	msi45win60_url = 'http://download.microsoft.com/download/2/6/1/261fca42-22c0-4f91-9451-0e0f2e08356d/Windows6.0-KB942288-v2-x86.msu';
@@ -43,3 +42,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/msiproduct.iss
+++ b/scripts/products/msiproduct.iss
@@ -21,3 +21,5 @@ function msiproduct(const ProductID: string): boolean;
 begin
     Result := MsiQueryProductState(ProductID) = INSTALLSTATE_DEFAULT;
 end;
+
+[Setup]

--- a/scripts/products/sql2005express.iss
+++ b/scripts/products/sql2005express.iss
@@ -1,7 +1,7 @@
-// SQL Server Express is supported on x64 and EMT64 systems in Windows On Windows (WOW). SQL Server Express is not supported on IA64 systems
-// requires Microsoft .NET Framework 2.0 or later
-// SQLEXPR32.EXE is a smaller package that can be used to install SQL Server Express on 32-bit operating systems only. The larger SQLEXPR.EXE package supports installing onto both 32-bit and 64-bit (WOW install) operating systems. There is no other difference between these packages.
-// http://www.microsoft.com/download/en/details.aspx?id=15291
+; SQL Server Express is supported on x64 and EMT64 systems in Windows On Windows (WOW). SQL Server Express is not supported on IA64 systems
+; requires Microsoft .NET Framework 2.0 or later
+; SQLEXPR32.EXE is a smaller package that can be used to install SQL Server Express on 32-bit operating systems only. The larger SQLEXPR.EXE package supports installing onto both 32-bit and 64-bit (WOW install) operating systems. There is no other difference between these packages.
+; http://www.microsoft.com/download/en/details.aspx?id=15291
 
 [CustomMessages]
 sql2005express_title=SQL Server 2005 Express SP3
@@ -11,7 +11,6 @@ de.sql2005express_size=38,1 MB
 
 en.sql2005express_size_x64=58.1 MB
 de.sql2005express_size_x64=58,1 MB
-
 
 [Code]
 const
@@ -40,3 +39,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/sql2008express.iss
+++ b/scripts/products/sql2008express.iss
@@ -1,9 +1,9 @@
-// requires Windows 7, Windows Server 2003, Windows Server 2008, Windows Server 2008 R2, Windows Vista, Windows XP
-// requires Microsoft .NET Framework 3.5 SP 1 or later
-// requires Windows Installer 4.5 or later
-// SQL Server Express is supported on x64 and EMT64 systems in Windows On Windows (WOW). SQL Server Express is not supported on IA64 systems
-// SQLEXPR32.EXE is a smaller package that can be used to install SQL Server Express on 32-bit operating systems only. The larger SQLEXPR.EXE package supports installing onto both 32-bit and 64-bit (WOW install) operating systems. There is no other difference between these packages.
-// http://www.microsoft.com/download/en/details.aspx?id=3743
+; requires Windows 7, Windows Server 2003, Windows Server 2008, Windows Server 2008 R2, Windows Vista, Windows XP
+; requires Microsoft .NET Framework 3.5 SP 1 or later
+; requires Windows Installer 4.5 or later
+; SQL Server Express is supported on x64 and EMT64 systems in Windows On Windows (WOW). SQL Server Express is not supported on IA64 systems
+; SQLEXPR32.EXE is a smaller package that can be used to install SQL Server Express on 32-bit operating systems only. The larger SQLEXPR.EXE package supports installing onto both 32-bit and 64-bit (WOW install) operating systems. There is no other difference between these packages.
+; http://www.microsoft.com/download/en/details.aspx?id=3743
 
 [CustomMessages]
 sql2008expressr2_title=SQL Server 2008 Express R2
@@ -13,7 +13,6 @@ de.sql2008expressr2_size=58,2 MB
 
 en.sql2008expressr2_size_x64=74.1 MB
 de.sql2008expressr2_size_x64=74,1 MB
-
 
 [Code]
 const
@@ -37,3 +36,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/sqlcompact35sp2.iss
+++ b/scripts/products/sqlcompact35sp2.iss
@@ -4,7 +4,6 @@ sqlcompact35sp2_title=SQL Server Compact 3.5 Service Pack 2
 en.sqlcompact35sp2_size=5.3 MB
 de.sqlcompact35sp2_size=5,3 MB
 
-
 [Code]
 const
 	sqlcompact35sp2_url = 'http://download.microsoft.com/download/E/C/1/EC1B2340-67A0-4B87-85F0-74D987A27160/SSCERuntime-ENU.exe';
@@ -19,3 +18,5 @@ begin
 			sqlcompact35sp2_url,
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/stringversion.iss
+++ b/scripts/products/stringversion.iss
@@ -1,3 +1,4 @@
+[Code]
 function stringtoversion(var temp: String): Integer;
 var
 	part: String;
@@ -57,3 +58,5 @@ begin
     temp2 := versionB;
     Result := compareinnerversion(temp1, temp2);
 end;
+
+[Setup]

--- a/scripts/products/vcredist2005.iss
+++ b/scripts/products/vcredist2005.iss
@@ -1,6 +1,6 @@
-// requires Windows 2000 Service Pack 3, Windows 98, Windows 98 Second Edition, Windows ME, Windows Server 2003, Windows XP Service Pack 2
-// requires Windows Installer 3.0
-// http://www.microsoft.com/en-us/download/details.aspx?id=3387
+; requires Windows 2000 Service Pack 3, Windows 98, Windows 98 Second Edition, Windows ME, Windows Server 2003, Windows XP Service Pack 2
+; requires Windows Installer 3.0
+; http://www.microsoft.com/en-us/download/details.aspx?id=3387
 
 [CustomMessages]
 vcredist2005_title=Visual C++ 2005 Redistributable
@@ -15,7 +15,6 @@ de.vcredist2005_size_x64=4,1 MB
 
 en.vcredist2005_size_ia64=8.8 MB
 de.vcredist2005_size_ia64=8,8 MB
-
 
 [Code]
 const
@@ -37,3 +36,5 @@ begin
 			GetString(vcredist2005_url, vcredist2005_url_x64, vcredist2005_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/vcredist2008.iss
+++ b/scripts/products/vcredist2008.iss
@@ -1,6 +1,6 @@
-// requires Windows 2000 Service Pack 4, Windows Server 2003, Windows Vista, Windows XP
-// requires Windows Installer 3.0
-// http://www.microsoft.com/en-us/download/details.aspx?id=29
+; requires Windows 2000 Service Pack 4, Windows Server 2003, Windows Vista, Windows XP
+; requires Windows Installer 3.0
+; http://www.microsoft.com/en-us/download/details.aspx?id=29
 
 [CustomMessages]
 vcredist2008_title=Visual C++ 2008 Redistributable
@@ -15,7 +15,6 @@ de.vcredist2008_size_x64=2,3 MB
 
 en.vcredist2008_size_ia64=4.0 MB
 de.vcredist2008_size_ia64=4,0 MB
-
 
 [Code]
 const
@@ -37,3 +36,5 @@ begin
 			GetString(vcredist2008_url, vcredist2008_url_x64, vcredist2008_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/vcredist2010.iss
+++ b/scripts/products/vcredist2010.iss
@@ -1,5 +1,5 @@
-// requires Windows 7, Windows Server 2003 R2 (32-Bit x86), Windows Server 2003 Service Pack 2, Windows Server 2008 R2, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2, Windows XP Service Pack 3
-// http://www.microsoft.com/en-us/download/details.aspx?id=5555
+; requires Windows 7, Windows Server 2003 R2 (32-Bit x86), Windows Server 2003 Service Pack 2, Windows Server 2008 R2, Windows Server 2008 Service Pack 2, Windows Vista Service Pack 2, Windows XP Service Pack 3
+; http://www.microsoft.com/en-us/download/details.aspx?id=5555
 
 [CustomMessages]
 vcredist2010_title=Visual C++ 2010 Redistributable
@@ -14,7 +14,6 @@ de.vcredist2010_size_x64=5,5 MB
 
 en.vcredist2010_size_ia64=2.2 MB
 de.vcredist2010_size_ia64=2,2 MB
-
 
 [Code]
 const
@@ -36,3 +35,5 @@ begin
 			GetString(vcredist2010_url, vcredist2010_url_x64, vcredist2010_url_ia64),
 			false, false, false);
 end;
+
+[Setup]

--- a/scripts/products/vcredist2012.iss
+++ b/scripts/products/vcredist2012.iss
@@ -1,5 +1,5 @@
-// requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP
-// http://www.microsoft.com/en-us/download/details.aspx?id=30679
+; requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP
+; http://www.microsoft.com/en-us/download/details.aspx?id=30679
 
 [CustomMessages]
 vcredist2012_title=Visual C++ 2012 Redistributable
@@ -10,7 +10,6 @@ de.vcredist2012_size=6,3 MB
 
 en.vcredist2012_size_x64=6.4 MB
 de.vcredist2012_size_x64=6,4 MB
-
 
 [Code]
 const
@@ -32,3 +31,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/vcredist2013.iss
+++ b/scripts/products/vcredist2013.iss
@@ -1,5 +1,5 @@
-// requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2, Windows XP
-// http://www.microsoft.com/en-US/download/details.aspx?id=40784
+; requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2, Windows XP
+; http://www.microsoft.com/en-US/download/details.aspx?id=40784
 
 [CustomMessages]
 vcredist2013_title=Visual C++ 2013 Redistributable
@@ -10,7 +10,6 @@ de.vcredist2013_size=6,2 MB
 
 en.vcredist2013_size_x64=6.9 MB
 de.vcredist2013_size_x64=6,9 MB
-
 
 [Code]
 const
@@ -32,3 +31,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/vcredist2015.iss
+++ b/scripts/products/vcredist2015.iss
@@ -1,5 +1,5 @@
-// requires Windows 10, Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003 Service Pack 2, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP Service Pack 3
-// http://www.microsoft.com/en-US/download/details.aspx?id=48145
+; requires Windows 10, Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003 Service Pack 2, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP Service Pack 3
+; http://www.microsoft.com/en-US/download/details.aspx?id=48145
 
 [CustomMessages]
 vcredist2015_title=Visual C++ 2015 Redistributable
@@ -10,7 +10,6 @@ de.vcredist2015_size=12,8 MB
 
 en.vcredist2015_size_x64=13.9 MB
 de.vcredist2015_size_x64=13,9 MB
-
 
 [Code]
 const
@@ -32,3 +31,5 @@ begin
 				false, false, false);
 	end;
 end;
+
+[Setup]

--- a/scripts/products/wic.iss
+++ b/scripts/products/wic.iss
@@ -1,11 +1,10 @@
-//requires Windows Server 2003, Windows Server 2003 R2 Datacenter Edition (32-Bit x86), Windows Server 2003 R2 Enterprise Edition (32-Bit x86), Windows Server 2003 R2 Standard Edition (32-bit x86), Windows XP Service Pack 2
+; requires Windows Server 2003, Windows Server 2003 R2 Datacenter Edition (32-Bit x86), Windows Server 2003 R2 Enterprise Edition (32-Bit x86), Windows Server 2003 R2 Standard Edition (32-bit x86), Windows XP Service Pack 2
 
 [CustomMessages]
 wic_title=Windows Imaging Component
  
 en.wic_size=1.2 MB
 de.wic_size=1,2 MB
- 
 
 [Code]
 const
@@ -53,3 +52,5 @@ begin
 		end;
 	end;
 end;
+
+[Setup]

--- a/scripts/products/winversion.iss
+++ b/scripts/products/winversion.iss
@@ -45,3 +45,5 @@ begin
 	else
 		Result := true;
 end;
+
+[Setup]


### PR DESCRIPTION
This normalisation makes it easy to actually use the include files in any InnoSetup script without worrying about the order in which to include files and whether an included files leaves a [Code] section open. Leaked [Code] sections change the comment syntax for everything that follows. This can lead to a big mess if not handled carefully. My change never leaves a [Code] section open at the end of a file which avoids this kind of problem completely.