### PR TITLE
Replaced installing .NET 4.6 with .NET 4.6.1

### DIFF
--- a/scripts/products/dotnetfx46.iss
+++ b/scripts/products/dotnetfx46.iss
@@ -1,11 +1,11 @@
-; requires Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2
+; requires Windows 10, Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Server 2012 R2, Windows Vista Service Pack 2
 ; WARNING: express setup (downloads and installs the components depending on your OS) if you want to deploy it on cd or network download the full bootsrapper on website below
-; http://www.microsoft.com/en-us/download/details.aspx?id=48137
+; https://www.microsoft.com/en-US/download/details.aspx?id=49982
 
 [CustomMessages]
-dotnetfx46_title=.NET Framework 4.6
+dotnetfx46_title=.NET Framework 4.6.1
 
-dotnetfx46_size=1 MB - 63 MB
+dotnetfx46_size=1 MB - 65 MB
 
 ;http://www.microsoft.com/globaldev/reference/lcid-all.mspx
 en.dotnetfx46_lcid=
@@ -13,7 +13,7 @@ de.dotnetfx46_lcid=/lcid 1031
 
 [Code]
 const
-	dotnetfx46_url = 'http://download.microsoft.com/download/1/4/A/14A6C422-0D3C-4811-A31F-5EF91A83C368/NDP46-KB3045560-Web.exe';
+	dotnetfx461_url = 'http://download.microsoft.com/download/3/5/9/35980F81-60F4-4DE3-88FC-8F962B97253B/NDP461-KB3102438-Web.exe';
 
 procedure dotnetfx46(minVersion: integer);
 begin
@@ -22,7 +22,7 @@ begin
 			CustomMessage('dotnetfx46_lcid') + ' /passive /norestart',
 			CustomMessage('dotnetfx46_title'),
 			CustomMessage('dotnetfx46_size'),
-			dotnetfx46_url,
+			dotnetfx461_url,
 			false, false, false);
 end;
 


### PR DESCRIPTION
.NET 4.6.1 is an in-place update for .NET 4.6.
It is more meaningful to install the latest version, we avoid some feature updates for the user. Every application will still work. If .NET 4.6 is installed, no upgrade to .NET 4.6.1 is started. It's only if you need .NET 4.6.x either way.