### PR TITLE
Fix "Unknown language name" compiler errors

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -81,6 +81,10 @@ DisableReadyMemo=no
 [Languages]
 Name: "en"; MessagesFile: "compiler:Default.isl"
 Name: "de"; MessagesFile: "compiler:Languages\German.isl"
+Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
+Name: "it"; MessagesFile: "compiler:Languages\Italian.isl"
+Name: "nl"; MessagesFile: "compiler:Languages\Dutch.isl"
+Name: "pl"; MessagesFile: "compiler:Languages\Polish.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"


### PR DESCRIPTION
Was getting:

    Compiler Error!
    File: C:\innodependencyinstaller\scripts\products.iss  Line 8: Unknown language name "fr"
