### PR TITLE
MSVC2015 Update 3 and more robust detection method

### DIFF
--- a/scripts/products/msiproduct.iss
+++ b/scripts/products/msiproduct.iss
@@ -22,4 +22,28 @@ begin
     Result := MsiQueryProductState(ProductID) = INSTALLSTATE_DEFAULT;
 end;
 
+function MsiEnumRelatedProducts(szUpgradeCode: String; nReserved: DWORD; nIndex: DWORD; szProductCode: String): Integer;
+external 'MsiEnumRelatedProducts{#AW}@msi.dll stdcall';
+function MsiGetProductInfo(szProductCode: String; szProperty: String; szValue: String; var nValueBufSize: DWORD): Integer;
+external 'MsiGetProductInfo{#AW}@msi.dll stdcall';
+function MsiProductInstalled(szUpgradeCode: String; nProductVersion: DWORD): Boolean;
+var
+    szProductCode, szValue, szBuild: String;
+    nValueBufSize, nBuild: DWORD;
+begin
+    SetLength( szProductCode, 39 );
+    SetLength( szValue, 39 );
+    nValueBufSize := Length( szValue );
+    Result := false;
+    if ( MsiEnumRelatedProducts( szUpgradeCode, 0, 0, szProductCode ) = 0 ) then begin
+        if ( MsiGetProductInfo( szProductCode, 'VersionString', szValue, nValueBufSize ) = 0 ) then begin
+            szBuild := ExtractFileExt( szValue );
+            szBuild := Copy( szBuild, 2, Length( szBuild ) - 1 );
+            nBuild := StrToInt( szBuild );
+            if ( nBuild >= nProductVersion ) then begin
+                Result := true;
+            end;
+        end;
+    end;
+end;
 [Setup]

--- a/scripts/products/vcredist2015.iss
+++ b/scripts/products/vcredist2015.iss
@@ -1,35 +1,43 @@
-; requires Windows 10, Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003 Service Pack 2, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP Service Pack 3
-; http://www.microsoft.com/en-US/download/details.aspx?id=48145
+// requires Windows 10, Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003 Service Pack 2, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP Service Pack 3
+
+// Visual C++ Redistributable for Visual Studio 2015 Update 3 (14.0.24210)
+// https://www.visualstudio.com/downloads/download-visual-studio-vs#d-visual-c
 
 [CustomMessages]
-vcredist2015_title=Visual C++ 2015 Redistributable
-vcredist2015_title_x64=Visual C++ 2015 64-Bit Redistributable
+vcredist2015_title=Microsoft Visual C++ 2015 Update 3 Redistributable (x86)
+vcredist2015_title_x64=Microsoft Visual C++ 2015 Update 3 Redistributable (x64)
 
-en.vcredist2015_size=12.8 MB
-de.vcredist2015_size=12,8 MB
+en.vcredist2015_size=13.7 MB
+de.vcredist2015_size=13,7 MB
 
-en.vcredist2015_size_x64=13.9 MB
-de.vcredist2015_size_x64=13,9 MB
+en.vcredist2015_size_x64=14.5 MB
+de.vcredist2015_size_x64=14,5 MB
+
 
 [Code]
 const
-	vcredist2015_url = 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe';
-	vcredist2015_url_x64 = 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe';
+  vcredist_version_major = 14;
+  vcredist_version_minor = 0;
+  vcredist_version_build = 24210;
 
-	vcredist2015_productcode = '{74D0E5DB-B326-4DAE-A6B2-445B9DE1836E}';
-	vcredist2015_productcode_x64 = '{0D3E9E15-DE7A-300B-96F1-B4AF12B96488}';
+    vcredist2015_url = 'http://download.microsoft.com/download/d/e/c/dec58546-c2f5-40a7-b38e-4df8d60b9764/vc_redist.x86.exe';
+    vcredist2015_url_x64 = 'http://download.microsoft.com/download/2/c/6/2c675af0-2155-4961-b32e-289d7addfcec/vc_redist.x64.exe';
+
+    vcredist2015_productcode = '{8FD71E98-EE44-3844-9DAD-9CB0BBBC603C}';
+    vcredist2015_productcode_x64 = '{C0B2C673-ECAA-372D-94E5-E89440D087AD}';
+
+  vcredist2015_upgradecode = '{65E5BD06-6392-3027-8C26-853107D3CF1A}';
+  vcredist2015_upgradecode_x64 = '{36F68A90-239C-34DF-B58C-64B30153CE35}';
 
 procedure vcredist2015();
 begin
-	if (not IsIA64()) then begin
-		if (not msiproduct(GetString(vcredist2015_productcode, vcredist2015_productcode_x64, ''))) then
-			AddProduct('vcredist2015' + GetArchitectureString() + '.exe',
-				'/passive /norestart',
-				CustomMessage('vcredist2015_title' + GetArchitectureString()),
-				CustomMessage('vcredist2015_size' + GetArchitectureString()),
-				GetString(vcredist2015_url, vcredist2015_url_x64, ''),
-				false, false, false);
-	end;
+    if (not IsIA64()) then begin
+        if (not MsiProductInstalled(GetString(vcredist2015_upgradecode, vcredist2015_upgradecode_x64, ''), vcredist_version_build)) then
+            AddProduct('vcredist2015' + GetArchitectureString() + '.exe',
+                '/passive /norestart',
+                CustomMessage('vcredist2015_title' + GetArchitectureString()),
+                CustomMessage('vcredist2015_size' + GetArchitectureString()),
+                GetString(vcredist2015_url, vcredist2015_url_x64, ''),
+                false, false, false);
+    end;
 end;
-
-[Setup]


### PR DESCRIPTION
This should also fix these 2 issues:
Issue #9: Error when newer visual studio 2015 runtimes are installed
Issue #13: vcRedist x86 on x64 machine error in msiproduct

See comments to see how to update this code for the latest Update 3 Redistributable (yes, Microsoft is now updating the updates).
