### PR TITLE
Remove extra space on Ready to Install step

### DIFF
--- a/scripts/code.pas
+++ b/scripts/code.pas
@@ -208,10 +208,12 @@ begin
 	if installMemo <> '' then
 		s := s + CustomMessage('depinstall_memo_title') + ':' + NewLine + FmtMessage(installMemo, [Space]) + NewLine;
 
-	s := s + MemoDirInfo + NewLine + NewLine + MemoGroupInfo
-
+	if MemoDirInfo <> '' then
+		s := s + MemoDirInfo + NewLine + NewLine;
+	if MemoGroupInfo <> '' then
+		s := s + MemoGroupInfo + NewLine + NewLine;
 	if MemoTasksInfo <> '' then
-		s := s + NewLine + NewLine + MemoTasksInfo;
+		s := s + MemoTasksInfo;
 
 	Result := s
 end;


### PR DESCRIPTION
I found that MemoDirInfo and MemoGroupInfo may be empty during install. For example, when a user has already installed the application but is going to fix some accidentally removed files etc. This leads to extra space on the Ready to Install step like on the picture below. The problem can be avoided by checking every variable for empty state.

![extra space](https://cloud.githubusercontent.com/assets/10548881/25075106/11502454-2315-11e7-8acd-4b03f2751620.png)

Thanks.
